### PR TITLE
Fix CLI version to match platform packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@babel/core": "^7.25.2",
         "@babel/preset-env": "^7.25.3",
         "@babel/runtime": "^7.25.0",
-        "@react-native-community/cli": "latest",
+        "@react-native-community/cli": "18.0.0",
         "@react-native-community/cli-platform-android": "18.0.0",
         "@react-native-community/cli-platform-ios": "18.0.0",
         "@react-native/babel-preset": "0.79.2",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@babel/core": "^7.25.2",
     "@babel/preset-env": "^7.25.3",
     "@babel/runtime": "^7.25.0",
-    "@react-native-community/cli": "latest",
+    "@react-native-community/cli": "18.0.0",
     "@react-native-community/cli-platform-android": "18.0.0",
     "@react-native-community/cli-platform-ios": "18.0.0",
     "@react-native/babel-preset": "0.79.2",


### PR DESCRIPTION
## Summary
- lock @react-native-community/cli to version 18.0.0

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68449bc13ccc8332a40eb068b45f355c